### PR TITLE
[FEAT] 동시성 이슈 발생 가능성이 있는 기능에 동시성 처리 기능 추가

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/Inventory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/Inventory.java
@@ -32,4 +32,12 @@ public class Inventory extends BaseEntity {
     public boolean canOrder(Integer orderQuantity) {
         return this.quantity >= orderQuantity;
     }
+
+    public boolean isOptionOf(Long productId, Long productOptionId) {
+        return this.productId.equals(productId) && this.productOptionId.equals(productOptionId);
+    }
+
+    public void deduct(Integer quantity) {
+        this.quantity -= quantity;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/InventoryCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/InventoryCommand.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.inventory;
+
+import java.util.List;
+
+public class InventoryCommand {
+    public record Deduct(List<Option> options) {
+    }
+
+    public record Option(Long productId, Long productOptionId, Integer quantity) {
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/InventoryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/InventoryRepository.java
@@ -1,9 +1,12 @@
 package com.loopers.domain.inventory;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InventoryRepository {
     Optional<Inventory> find(Long productId, Long productOptionId);
 
     Inventory save(Inventory inventory);
+
+    List<Inventory> findAll(InventoryCommand.Deduct command);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/InventoryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/InventoryService.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.inventory;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class InventoryService {
+    private final InventoryRepository inventoryRepository;
+
+    @Transactional
+    public void deduct(InventoryCommand.Deduct command) {
+        List<Inventory> inventories = inventoryRepository.findAll(command);
+        inventories.forEach(
+            inventory -> command.options()
+                .stream()
+                .filter(option -> inventory.isOptionOf(option.productId(), option.productOptionId()))
+                .findFirst()
+                .ifPresent(option -> {
+                    if (inventory.canOrder(option.quantity())) {
+                        inventory.deduct(option.quantity());
+                        inventoryRepository.save(inventory);
+                    }
+                })
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeSummary.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeSummary.java
@@ -6,12 +6,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "like_summary")
+@Table(
+    name = "like_summary",
+    uniqueConstraints = @UniqueConstraint(
+        columnNames = {"target_id", "target_type"}
+    )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LikeSummary {
@@ -23,6 +30,9 @@ public class LikeSummary {
 
     @Embedded
     private LikeTarget target;
+
+    @Version
+    private Long version;
 
     public LikeSummary(Long targetId, LikeTargetType targetType) {
         this.target = new LikeTarget(targetId, targetType);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -3,7 +3,7 @@ package com.loopers.domain.order;
 import java.util.List;
 
 public class OrderCommand {
-    public record Place(
+    public record Order(
         Long userId,
         List<OrderOption> options
     ) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -17,7 +17,7 @@ public class OrderService {
     private final OrderValidator orderValidator;
 
     @Transactional
-    public OrderInfo place(OrderCommand.Place command) {
+    public OrderInfo order(OrderCommand.Order command) {
         List<OrderItem> orderItems = command.options().stream()
             .map(OrderCommand.OrderOption::toOrderItem)
             .toList();

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,6 +41,9 @@ public class User extends BaseEntity {
     private String email;
 
     private int point;
+
+    @Version
+    private Long version;
 
     public User(String userId, Gender gender, String birthDate, String email) {
         validateUserId(userId);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -10,14 +10,13 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.Getter;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "user")
@@ -84,6 +83,10 @@ public class User extends BaseEntity {
 
     public void updatePoint(int balance) {
         this.point = balance;
+    }
+
+    public void usePoint(int amount) {
+        this.point -= amount;
     }
 
     public void chargePoint(int amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -48,8 +48,8 @@ public class UserService {
     }
 
     @Transactional
-    public void pay(Long aLong, BigDecimal totalPrice) {
-        User user = userRepository.find(aLong).orElseThrow();
+    public void pay(Long id, BigDecimal totalPrice) {
+        User user = userRepository.find(id).orElseThrow();
         user.usePoint(totalPrice.intValue());
         userRepository.save(user);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.user;
 
+import java.math.BigDecimal;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,5 +45,12 @@ public class UserService {
             .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 ID의 유저가 존재하지 않습니다. [userId = " + userId + "]"));
         user.updatePoint(balance);
         return UserInfo.from(userRepository.save(user));
+    }
+
+    @Transactional
+    public void pay(Long aLong, BigDecimal totalPrice) {
+        User user = userRepository.find(aLong).orElseThrow();
+        user.usePoint(totalPrice.intValue());
+        userRepository.save(user);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryJpaRepository.java
@@ -1,11 +1,19 @@
 package com.loopers.infrastructure.inventory;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import com.loopers.domain.inventory.Inventory;
 
+import jakarta.persistence.LockModeType;
+
 public interface InventoryJpaRepository extends JpaRepository<Inventory, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Inventory> findByProductIdAndProductOptionId(Long productId, Long productOptionId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<Inventory> findByProductIdInAndProductOptionIdIn(List<Long> productIds, List<Long> productOptionIds);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryRepositoryImpl.java
@@ -1,10 +1,12 @@
 package com.loopers.infrastructure.inventory;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
 import com.loopers.domain.inventory.Inventory;
+import com.loopers.domain.inventory.InventoryCommand;
 import com.loopers.domain.inventory.InventoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -22,5 +24,19 @@ public class InventoryRepositoryImpl implements InventoryRepository {
     @Override
     public Inventory save(Inventory inventory) {
         return inventoryJpaRepository.save(inventory);
+    }
+
+    @Override
+    public List<Inventory> findAll(InventoryCommand.Deduct command) {
+        List<Long> productIds = command.options().stream().map(InventoryCommand.Option::productId).toList();
+        List<Long> productOptionIds = command.options().stream().map(InventoryCommand.Option::productOptionId).toList();
+
+        List<Inventory> inventories = inventoryJpaRepository.findByProductIdInAndProductOptionIdIn(productIds, productOptionIds);
+
+        if (inventories.size() != command.options().size()) {
+            throw new IllegalArgumentException("Some inventories were not found for the provided product and option IDs.");
+        }
+
+        return inventories;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -2,10 +2,13 @@ package com.loopers.infrastructure.user;
 
 import java.util.Optional;
 
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Repository;
 
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 
 @Repository
 public class UserRepositoryImpl implements UserRepository {
@@ -23,12 +26,20 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public Optional<User> find(String userId) {
-        return userJpaRepository.findByUserId(userId);
+        try {
+            return userJpaRepository.findByUserId(userId);
+        } catch (OptimisticLockingFailureException exception) {
+            throw new CoreException(ErrorType.CONFLICT);
+        }
     }
 
     @Override
     public Optional<User> find(Long id) {
-        return userJpaRepository.findById(id);
+        try {
+            return userJpaRepository.findById(id);
+        } catch (OptimisticLockingFailureException exception) {
+            throw new CoreException(ErrorType.CONFLICT);
+        }
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -35,7 +35,7 @@ public class OrderV1Controller implements OrderV1ApiSpec {
         @RequestBody OrderRequest request) {
         var orderOptions = request.toOrderOptions();
         UserInfo user = userService.get(userId);
-        OrderCommand.Place command = new OrderCommand.Place(user.id(), orderOptions);
+        OrderCommand.Order command = new OrderCommand.Order(user.id(), orderOptions);
         OrderResult result = orderFacade.placeOrder(command);
         return ApiResponse.success(OrderResponse.from(result));
     }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -1,0 +1,279 @@
+package com.loopers.application.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.loopers.domain.inventory.Inventory;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductOption;
+import com.loopers.domain.product.ProductStatus;
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.infrastructure.inventory.InventoryJpaRepository;
+import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.utils.DatabaseCleanUp;
+
+@SpringBootTest
+class OrderFacadeIntegrationTest {
+
+    @Autowired
+    private OrderFacade orderFacade;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private InventoryJpaRepository inventoryJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("포인트로 새로운 주문을 시도할 때, ")
+    @Nested
+    class OrderWithPoint {
+        @DisplayName("유효한 주문 옵션 목록을 주면, 주문 결과를 반환한다. ")
+        @Test
+        void returnsOrderResults_whenValidOrderOptionsProvided() {
+            // arrange
+            User user = new User("testUser", Gender.MALE, "1997-06-05", "testUser@mail.com");
+            user.updatePoint(40000);
+            userJpaRepository.save(user);
+
+            Product product = new Product(
+                "상품1",
+                null,
+                BigDecimal.valueOf(20000),
+                ProductStatus.ON_SALE,
+                1L,
+                1L,
+                LocalDateTime.now().plusDays(3)
+            );
+            ProductOption productOption = new ProductOption("SIZE", "M", BigDecimal.ZERO);
+            product.addOption(productOption);
+            int initialStock = 5;
+            Inventory inventory = new Inventory(1L, 1L, initialStock);
+            productJpaRepository.save(product);
+            inventoryJpaRepository.save(inventory);
+
+            OrderCommand.Order command = new OrderCommand.Order(1L, List.of(new OrderCommand.OrderOption(1L, 1L, 2)));
+
+            // act
+            OrderResult result = orderFacade.placeOrder(command);
+
+            // assert
+            Optional<User> savedUser = userJpaRepository.findById(1L);
+            assertThat(savedUser.isPresent()).isTrue();
+            assertAll(
+                () -> assertThat(result.userId()).isEqualTo(1L),
+                () -> assertThat(result.totalPrice()).isEqualByComparingTo(BigDecimal.valueOf(40000)),
+                () -> assertThat(savedUser.get().getPoint()).isEqualTo(0),
+                () -> assertThat(result.paymentMethod()).isEqualTo(PaymentMethod.POINT),
+                () -> assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED),
+                () -> assertThat(result.status()).isEqualTo(OrderStatus.PAYMENT_COMPLETED),
+                () -> assertThat(result.items().get(0).productId()).isEqualTo(1L),
+                () -> assertThat(result.items().get(0).productOptionId()).isEqualTo(1L),
+                () -> assertThat(result.items().get(0).quantity()).isEqualTo(2)
+            );
+        }
+    }
+
+    @DisplayName("동일한 상품에 대해 동시에 주문을 요청할 때, ")
+    @Nested
+    class Concurrency {
+        @DisplayName("두개의 주문 중 한 주문에 의해 재고가 부족해지는 경우, 하나만 성공하고 다른 주문은 실패한다")
+        @Test
+        void shouldPreventOverselling_whenConcurrentOrders() throws InterruptedException {
+            // arrange
+            User user1 = new User("testUser", Gender.MALE, "1997-06-05", "testUser@mail.com");
+            user1.updatePoint(1000000);
+            userJpaRepository.save(user1);
+            User user2 = new User("testUser", Gender.MALE, "1997-06-05", "testUser@mail.com");
+            user2.updatePoint(1000000);
+            userJpaRepository.save(user2);
+
+            Product product = new Product(
+                "상품1",
+                null,
+                BigDecimal.valueOf(20000),
+                ProductStatus.ON_SALE,
+                1L,
+                1L,
+                LocalDateTime.now().plusDays(3)
+            );
+            ProductOption productOption = new ProductOption("SIZE", "M", BigDecimal.ZERO);
+            product.addOption(productOption);
+            int initialStock = 5;
+            Inventory inventory = new Inventory(1L, 1L, initialStock);
+            productJpaRepository.save(product);
+            inventoryJpaRepository.save(inventory);
+
+            ExecutorService executorService = Executors.newFixedThreadPool(2);
+            CountDownLatch countDownLatch = new CountDownLatch(2);
+
+            // act
+            List<Future<OrderResult>> futures = new ArrayList<>();
+
+            // 첫 번째 주문 (4개)
+            futures.add(executorService.submit(() -> {
+                try {
+                    return orderFacade.placeOrder(new OrderCommand.Order(1L, List.of(new OrderCommand.OrderOption(1L, 1L, 4))));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            // 두 번째 주문 (3개)
+            futures.add(executorService.submit(() -> {
+                try {
+                    return orderFacade.placeOrder(new OrderCommand.Order(2L, List.of(new OrderCommand.OrderOption(1L, 1L, 3))));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            countDownLatch.await();
+
+            // assert
+            long successfulOrders = futures.stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .count();
+
+            Optional<Inventory> savedInv = inventoryJpaRepository.findById(1L);
+            Optional<User> savedUser1 = userJpaRepository.findById(1L);
+            Optional<User> savedUser2 = userJpaRepository.findById(2L);
+            assertThat(savedInv.isPresent()).isTrue();
+            assertThat(savedUser1.isPresent()).isTrue();
+            assertThat(savedUser2.isPresent()).isTrue();
+            assertAll(
+                () -> assertThat(successfulOrders).isEqualTo(1),
+                () -> assertThat(savedInv.get().getQuantity()).isEqualTo(2)
+            );
+        }
+
+        @DisplayName("재고가 충분하다면, 모든 주문을 정상적으로 완료시킨다.")
+        @Test
+        void completeAllOrders_whenSufficientStock() throws InterruptedException {
+            User user1 = new User("testUser1", Gender.MALE, "1997-06-05", "testUser@mail.com");
+            user1.updatePoint(6000000);
+            userJpaRepository.save(user1);
+            User user2 = new User("testUser2", Gender.MALE, "1997-06-05", "testUser@mail.com");
+            user2.updatePoint(6000000);
+            userJpaRepository.save(user2);
+            User user3 = new User("testUser3", Gender.MALE, "1997-06-05", "testUser@mail.com");
+            user3.updatePoint(6000000);
+            userJpaRepository.save(user3);
+
+            Product product = new Product(
+                "상품1",
+                null,
+                BigDecimal.valueOf(20000),
+                ProductStatus.ON_SALE,
+                1L,
+                1L,
+                LocalDateTime.now().plusDays(3)
+            );
+            ProductOption productOption = new ProductOption("SIZE", "M", BigDecimal.ZERO);
+            product.addOption(productOption);
+            int initialStock = 10;
+            Inventory inventory = new Inventory(1L, 1L, initialStock);
+            productJpaRepository.save(product);
+            inventoryJpaRepository.save(inventory);
+
+            ExecutorService executorService = Executors.newFixedThreadPool(2);
+            CountDownLatch countDownLatch = new CountDownLatch(2);
+
+            // act
+            List<Future<OrderResult>> futures = new ArrayList<>();
+
+            // 첫 번째 주문 (4개)
+            futures.add(executorService.submit(() -> {
+                try {
+                    return orderFacade.placeOrder(new OrderCommand.Order(1L, List.of(new OrderCommand.OrderOption(1L, 1L, 4))));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            // 두 번째 주문 (3개)
+            futures.add(executorService.submit(() -> {
+                try {
+                    return orderFacade.placeOrder(new OrderCommand.Order(2L, List.of(new OrderCommand.OrderOption(1L, 1L, 3))));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            // 세 번째 주문 (3개)
+            futures.add(executorService.submit(() -> {
+                try {
+                    return orderFacade.placeOrder(new OrderCommand.Order(3L, List.of(new OrderCommand.OrderOption(1L, 1L, 3))));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            countDownLatch.await();
+
+            // assert
+            long successfulOrders = futures.stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .count();
+
+            Optional<Inventory> savedInv = inventoryJpaRepository.findById(1L);
+            Optional<User> savedUser1 = userJpaRepository.findById(1L);
+            Optional<User> savedUser2 = userJpaRepository.findById(2L);
+            assertThat(savedInv.isPresent()).isTrue();
+            assertThat(savedUser1.isPresent()).isTrue();
+            assertThat(savedUser2.isPresent()).isTrue();
+            assertAll(
+                () -> assertThat(successfulOrders).isEqualTo(3),
+                () -> assertThat(savedInv.get().getQuantity()).isEqualTo(0)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- 여러 사용자가 동시에 재고를 차감하려고 할 때
  - 비관적 락 적용
  - 다른 사용자에 의해 재고가 부족해질 경우 실패한다. 
  - 재고가 충분하면 모든 요청을 허용한다. 
- 한 사용자가 동시에 두번 결제 요청을 보낼 경우
  - 낙관적 락 적용
  - 하나의 요청만 허용한다. 
- 여러 사용자가 하나의 상품에 동시에 좋아요를 할 때 
  - 낙관적 락 적용
  - 하나의 요청만 허용한다. 

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

재고는 인기가 많은 상품의 경우 높은 경합률을 보일 것으로 예상하기 때문에 비관적락으로 처리합니다. 

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
- [x] 멀티 스레드를 활용한 동시성 테스트를 추가한다.