### PR TITLE
[FEAT] 쿠폰 도메인, 쿠폰 사용 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -5,12 +5,22 @@ import java.math.BigDecimal;
 import com.loopers.domain.BaseEntity;
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
+@Table(name = "coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon extends BaseEntity {
     private String name;
     private String description;
+    @Enumerated(EnumType.STRING)
     private CouponType couponType;
     private Long discountRate;
     private Long discountAmount;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,0 +1,69 @@
+package com.loopers.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class Coupon {
+    private String name;
+    private String description;
+    private CouponType couponType;
+    private Long discountRate;
+    private Long discountAmount;
+    private Long minimumOrderAmount;
+    private Long maximumDiscountAmount;
+    private Integer limitCount;
+    private Integer usedCount;
+
+    private Coupon(String name, String description, CouponType couponType, Long discountRate, Long discountAmount,
+        Long minimumOrderAmount, Long maximumDiscountAmount, Integer limitCount, Integer usedCount) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("쿠폰 이름은 비어있을 수 없습니다.");
+        }
+
+        this.name = name;
+        this.description = description;
+        this.couponType = couponType;
+        this.discountRate = discountRate;
+        this.discountAmount = discountAmount;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.maximumDiscountAmount = maximumDiscountAmount;
+        this.limitCount = limitCount;
+        this.usedCount = usedCount;
+    }
+
+    public static Coupon fixedAmount(String name, String description, Long discountAmount, Long minimumOrderAmount,
+        Integer limitCount) {
+        if (discountAmount == null) {
+            throw new IllegalArgumentException("정액 할인 쿠폰은 할인 가격이 필수입니다.");
+        }
+        if (discountAmount <= 0) {
+            throw new IllegalArgumentException("정액 할인 가격은 0 보다 커야합니다.");
+        }
+        if (minimumOrderAmount == null) {
+            throw new IllegalArgumentException("정액 할인 쿠폰은 할인 최소 가격이 필수입니다.");
+        }
+        if (minimumOrderAmount < 0) {
+            throw new IllegalArgumentException("할인 최소 가격은 0이상이어야 합니다.");
+        }
+        return new Coupon(name, description, CouponType.FIXED_AMOUNT, null, discountAmount, minimumOrderAmount, null, limitCount,
+            0);
+    }
+
+    public static Coupon percentage(String name, String description, Long discountRate, Long maximumDiscountAmount,
+        Integer limitCount) {
+        if (discountRate == null) {
+            throw new IllegalArgumentException("정률 할인 쿠폰은 할인율이 필수 입니다.");
+        }
+        if (discountRate <= 0) {
+            throw new IllegalArgumentException("할인율은 0 보다 커야 합니다.");
+        }
+        if (maximumDiscountAmount == null) {
+            throw new IllegalArgumentException("정률 할인 쿠폰은 최대 할인 가격이 필수입니다.");
+        }
+        if (maximumDiscountAmount <= 0) {
+            throw new IllegalArgumentException("최대 할인 가격은 0 보다 커야합니다.");
+        }
+        return new Coupon(name, description, CouponType.PERCENTAGE, discountRate, null, null, maximumDiscountAmount, limitCount,
+            0);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,9 +1,14 @@
 package com.loopers.domain.coupon;
 
+import java.math.BigDecimal;
+
+import com.loopers.domain.BaseEntity;
+
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 
 @Getter
-public class Coupon {
+public class Coupon extends BaseEntity {
     private String name;
     private String description;
     private CouponType couponType;
@@ -19,6 +24,12 @@ public class Coupon {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("쿠폰 이름은 비어있을 수 없습니다.");
         }
+        if (minimumOrderAmount == null) {
+            throw new IllegalArgumentException("할인 최소 가격은 필수입니다.");
+        }
+        if (minimumOrderAmount < 0) {
+            throw new IllegalArgumentException("할인 최소 가격은 0이상이어야 합니다.");
+        }
 
         this.name = name;
         this.description = description;
@@ -32,25 +43,20 @@ public class Coupon {
     }
 
     public static Coupon fixedAmount(String name, String description, Long discountAmount, Long minimumOrderAmount,
-        Integer limitCount) {
+        @Nullable Integer limitCount) {
         if (discountAmount == null) {
             throw new IllegalArgumentException("정액 할인 쿠폰은 할인 가격이 필수입니다.");
         }
         if (discountAmount <= 0) {
             throw new IllegalArgumentException("정액 할인 가격은 0 보다 커야합니다.");
         }
-        if (minimumOrderAmount == null) {
-            throw new IllegalArgumentException("정액 할인 쿠폰은 할인 최소 가격이 필수입니다.");
-        }
-        if (minimumOrderAmount < 0) {
-            throw new IllegalArgumentException("할인 최소 가격은 0이상이어야 합니다.");
-        }
         return new Coupon(name, description, CouponType.FIXED_AMOUNT, null, discountAmount, minimumOrderAmount, null, limitCount,
             0);
     }
 
-    public static Coupon percentage(String name, String description, Long discountRate, Long maximumDiscountAmount,
-        Integer limitCount) {
+    public static Coupon percentage(String name, String description, Long discountRate, Long minimumOrderAmount,
+        Long maximumDiscountAmount,
+        @Nullable Integer limitCount) {
         if (discountRate == null) {
             throw new IllegalArgumentException("정률 할인 쿠폰은 할인율이 필수 입니다.");
         }
@@ -63,7 +69,12 @@ public class Coupon {
         if (maximumDiscountAmount <= 0) {
             throw new IllegalArgumentException("최대 할인 가격은 0 보다 커야합니다.");
         }
-        return new Coupon(name, description, CouponType.PERCENTAGE, discountRate, null, null, maximumDiscountAmount, limitCount,
+        return new Coupon(name, description, CouponType.PERCENTAGE, discountRate, null, minimumOrderAmount, maximumDiscountAmount,
+            limitCount,
             0);
+    }
+
+    public UserCoupon apply(Long userId, BigDecimal totalPrice, CouponDiscountStrategy strategy) {
+        return new UserCoupon(this, userId, strategy.calculateDiscount(this, totalPrice));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponDiscountStrategy.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public interface CouponDiscountStrategy {
+    boolean support(CouponType couponType);
+
+    BigDecimal calculateDiscount(Coupon coupon, BigDecimal price);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponDiscountStrategyFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponDiscountStrategyFactory.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.coupon;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CouponDiscountStrategyFactory {
+    private final List<CouponDiscountStrategy> discountStrategy;
+
+    public CouponDiscountStrategy get(Coupon coupon) {
+        return discountStrategy.stream()
+            .filter(strategy -> strategy.support(coupon.getCouponType()))
+            .findFirst()
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰에 해당하는 할인 전략이 없습니다."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Coupon save(Coupon coupon);
+
+    Optional<Coupon> find(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Component;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CouponService {
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final CouponDiscountStrategyFactory discountStrategyFactory;
+
+    public UserCoupon apply(Long userId, Long couponId, BigDecimal totalPrice) {
+        Coupon coupon = couponRepository.find(couponId)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[ID = " + couponId + "] 존재하지 않는 쿠폰입니다."));
+        UserCoupon userCoupon = coupon.apply(userId, totalPrice, discountStrategyFactory.get(coupon));
+        return userCouponRepository.save(userCoupon);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -19,6 +19,9 @@ public class CouponService {
     public UserCoupon apply(Long userId, Long couponId, BigDecimal totalPrice) {
         Coupon coupon = couponRepository.find(couponId)
             .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[ID = " + couponId + "] 존재하지 않는 쿠폰입니다."));
+        if (userCouponRepository.exists(userId, couponId)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이미 사용한 쿠폰입니다.");
+        }
         UserCoupon userCoupon = coupon.apply(userId, totalPrice, discountStrategyFactory.get(coupon));
         return userCouponRepository.save(userCoupon);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.coupon;
+
+public enum CouponType {
+    FIXED_AMOUNT,
+    PERCENTAGE
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountDiscountStrategy.java
@@ -2,8 +2,10 @@ package com.loopers.domain.coupon;
 
 import java.math.BigDecimal;
 
-public class FixedAmountDiscountStrategy implements CouponDiscountStrategy {
+import org.springframework.stereotype.Component;
 
+@Component
+public class FixedAmountDiscountStrategy implements CouponDiscountStrategy {
     @Override
     public boolean support(CouponType couponType) {
         return couponType == CouponType.FIXED_AMOUNT;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountDiscountStrategy.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public class FixedAmountDiscountStrategy implements CouponDiscountStrategy {
+
+    @Override
+    public boolean support(CouponType couponType) {
+        return couponType == CouponType.FIXED_AMOUNT;
+    }
+
+    @Override
+    public BigDecimal calculateDiscount(Coupon coupon, BigDecimal price) {
+        if (coupon.getMinimumOrderAmount() > price.intValue()) {
+            throw new IllegalStateException(
+                String.format("적용할 수 없는 쿠폰입니다. 주문 최소 가격: %s, 현재 가격: %s", coupon.getMinimumOrderAmount(), price));
+        }
+        return BigDecimal.valueOf(coupon.getDiscountAmount());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/PercentageDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/PercentageDiscountStrategy.java
@@ -3,6 +3,9 @@ package com.loopers.domain.coupon;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class PercentageDiscountStrategy implements CouponDiscountStrategy {
     @Override
     public boolean support(CouponType couponType) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/PercentageDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/PercentageDiscountStrategy.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class PercentageDiscountStrategy implements CouponDiscountStrategy {
+    @Override
+    public boolean support(CouponType couponType) {
+        return CouponType.PERCENTAGE == couponType;
+    }
+
+    @Override
+    public BigDecimal calculateDiscount(Coupon coupon, BigDecimal price) {
+        if (coupon.getMinimumOrderAmount() > price.intValue()) {
+            throw new IllegalStateException(
+                String.format("적용할 수 없는 쿠폰입니다. 주문 최소 가격: %s, 현재 가격: %s", coupon.getMinimumOrderAmount(), price));
+        }
+        return price.multiply(BigDecimal.valueOf(coupon.getDiscountRate()))
+            .divide(BigDecimal.valueOf(100), 0, RoundingMode.CEILING);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -8,13 +8,21 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "user_coupon")
+@Table(name = "user_coupon",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_user_coupon",
+            columnNames = {"user_id", "coupon_id"}
+        )
+    }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserCoupon extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -2,10 +2,22 @@ package com.loopers.domain.coupon;
 
 import java.math.BigDecimal;
 
-import lombok.Getter;
+import com.loopers.domain.BaseEntity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
 @Getter
-public class UserCoupon {
+@Table(name = "user_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCoupon extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
     private Coupon coupon;
     private Long userId;
     private BigDecimal discountAmount;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+import lombok.Getter;
+
+@Getter
+public class UserCoupon {
+    private Coupon coupon;
+    private Long userId;
+    private BigDecimal discountAmount;
+
+    public UserCoupon(Coupon coupon, Long userId, BigDecimal discountAmount) {
+        this.coupon = coupon;
+        this.userId = userId;
+        this.discountAmount = discountAmount;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.coupon;
+
+public interface UserCouponRepository {
+    UserCoupon save(UserCoupon userCoupon);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -2,4 +2,6 @@ package com.loopers.domain.coupon;
 
 public interface UserCouponRepository {
     UserCoupon save(UserCoupon userCoupon);
+
+    boolean exists(Long userId, Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponCoreRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponCoreRepository.java
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.coupon;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CouponCoreRepository implements CouponRepository {
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(coupon);
+    }
+
+    @Override
+    public Optional<Coupon> find(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.coupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.loopers.domain.coupon.Coupon;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponCoreRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponCoreRepository.java
@@ -16,4 +16,9 @@ public class UserCouponCoreRepository implements UserCouponRepository {
     public UserCoupon save(UserCoupon userCoupon) {
         return userCouponJpaRepository.save(userCoupon);
     }
+
+    @Override
+    public boolean exists(Long userId, Long couponId) {
+        return userCouponJpaRepository.existsByUserIdAndCouponId(userId, couponId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponCoreRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponCoreRepository.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.coupon;
+
+import org.springframework.stereotype.Component;
+
+import com.loopers.domain.coupon.UserCoupon;
+import com.loopers.domain.coupon.UserCouponRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserCouponCoreRepository implements UserCouponRepository {
+    private final UserCouponJpaRepository userCouponJpaRepository;
+
+    @Override
+    public UserCoupon save(UserCoupon userCoupon) {
+        return userCouponJpaRepository.save(userCoupon);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.loopers.domain.coupon.UserCoupon;
 
 public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long> {
+    boolean existsByUserIdAndCouponId(Long userId, Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.coupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.loopers.domain.coupon.UserCoupon;
+
+public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long> {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -66,5 +66,20 @@ class CouponServiceIntegrationTest {
             // assert
             assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
         }
+
+        @DisplayName("이미 사용된 쿠폰 ID를 주면, BAD REQUEST 예외를 발생한다.")
+        @Test
+        void throwsBadRequestException_whenAlreadyUsedCouponIdIsProvided() {
+            // arrange
+            Coupon coupon = couponJpaRepository.save(Coupon.fixedAmount("새로운 쿠폰", "쿠폰의 설명입니다.", 5000L, 30000L, null));
+            couponService.apply(1L, coupon.getId(), BigDecimal.valueOf(30000));
+
+            // act
+            var exception = assertThrows(CoreException.class, () ->
+                couponService.apply(1L, coupon.getId(), BigDecimal.valueOf(30000)));
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.loopers.infrastructure.coupon.CouponJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+
+@SpringBootTest
+class CouponServiceIntegrationTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("쿠폰을 사용할 때,")
+    @Nested
+    class Use {
+        @DisplayName("올바른 쿠폰 아이디를 주면 쿠폰을 생성한다.")
+        @Test
+        void useCoupon_whenValidCouponIdIsProvided() {
+            // arrange
+            Coupon coupon = couponJpaRepository.save(Coupon.fixedAmount("새로운 쿠폰", "쿠폰의 설명입니다.", 5000L, 30000L, null));
+
+            // act
+            UserCoupon userCoupon = couponService.apply(1L, coupon.getId(), BigDecimal.valueOf(30000));
+
+            // assert
+            assertAll(
+                () -> assertThat(userCoupon.getCoupon().getId()).isEqualTo(coupon.getId()),
+                () -> assertThat(userCoupon.getDiscountAmount()).isEqualByComparingTo(BigDecimal.valueOf(coupon.getDiscountAmount())),
+                () -> assertThat(userCoupon.getUserId()).isEqualTo(1L)
+            );
+        }
+
+        @DisplayName("존재하지 않는 쿠폰 ID를 주면, NOT FOUND 예외를 발생한다.")
+        @Test
+        void throwsNotFoundException_whenInvalidCouponIdIsProvided() {
+            // act
+            var exception = assertThrows(CoreException.class, () ->
+                couponService.apply(1L, 1L, BigDecimal.valueOf(30000))
+            );
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -5,6 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.loopers.infrastructure.coupon.CouponJpaRepository;
+import com.loopers.infrastructure.coupon.UserCouponJpaRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -26,6 +34,9 @@ class CouponServiceIntegrationTest {
 
     @Autowired
     private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private UserCouponJpaRepository userCouponJpaRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -80,6 +91,54 @@ class CouponServiceIntegrationTest {
 
             // assert
             assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("한명의 사용자가 동일한 쿠폰을 동시에 사용하면, 쿠폰 사용에 실패한다.")
+        @Test
+        void failsToApplyCoupon_whenSameUserTriesToApplyCouponSimultaneously() throws InterruptedException {
+            // arrange
+            Coupon coupon = couponJpaRepository.save(Coupon.fixedAmount("새로운 쿠폰", "쿠폰의 설명입니다.", 5000L, 30000L, null));
+
+            ExecutorService executorService = Executors.newFixedThreadPool(2);
+            CountDownLatch countDownLatch = new CountDownLatch(2);
+
+            // act
+            List<Future<UserCoupon>> futures = new ArrayList<>();
+
+            futures.add(executorService.submit(() -> {
+                try {
+                    return couponService.apply(1L, coupon.getId(), BigDecimal.valueOf(30000));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            futures.add(executorService.submit(() -> {
+                try {
+                    return couponService.apply(1L, coupon.getId(), BigDecimal.valueOf(30000));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+
+            countDownLatch.await();
+
+            // assert
+            long successCount = futures.stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .count();
+
+            assertAll(
+                () -> assertThat(successCount).isEqualTo(1),
+                () -> assertThat(userCouponJpaRepository.count()).isEqualTo(1)
+            );
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -1,0 +1,150 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CouponTest {
+
+    @DisplayName("쿠폰을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("이름이 null 이면, 생성에 실패한다. ")
+        @Test
+        void fail_whenNameIsNull() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class, () ->
+                Coupon.fixedAmount(null, "쿠폰 설명", 5000L, 20000L, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("쿠폰 이름은 비어있을 수 없습니다.");
+        }
+
+        @DisplayName("이름이 비어있으면, 생성에 실패한다.")
+        @Test
+        void fail_whenNameIsBlank() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class, () ->
+                Coupon.fixedAmount("", "쿠폰 설명", 5000L, 20000L, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("쿠폰 이름은 비어있을 수 없습니다.");
+        }
+    }
+
+    @DisplayName("정액 쿠폰을 생성할 때, ")
+    @Nested
+    class CreateFixedAmountCoupon {
+
+        @DisplayName("할인 가격이 없으면, 생성에 실패한다.")
+        @Test
+        void failCreateFixedCoupon_whenDiscountAmountIsNull() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.fixedAmount("쿠폰", "쿠폰쿠폰", null, null, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("정액 할인 쿠폰은 할인 가격이 필수입니다.");
+        }
+
+        @DisplayName("할인 가격이 0이하면, 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {0L, -1L})
+        void failCreateFixedCoupon_whenDiscountAmountIsZeroOrLess(long discountAmount) {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.fixedAmount("쿠폰", "쿠폰쿠폰", discountAmount, null, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("정액 할인 가격은 0 보다 커야합니다.");
+        }
+
+        @DisplayName("할인 최소 가격이 null 이면, 생성에 실패한다.")
+        @Test
+        void failCreateFixedCoupon_whenMinimumDiscountAmountIsNull() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.fixedAmount("쿠폰", "쿠폰쿠폰", 1000L, null, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("정액 할인 쿠폰은 할인 최소 가격이 필수입니다.");
+        }
+
+        @DisplayName("할인 최소 가격이 0보다 작으면, 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, -1111L})
+        void failCreateFixedCoupon_whenMinimumDiscountAmountIsLessThanZero(long minimumDiscountAmount) {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.fixedAmount("쿠폰", "쿠폰쿠폰", 1000L, minimumDiscountAmount, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("할인 최소 가격은 0이상이어야 합니다.");
+        }
+    }
+
+    @DisplayName("정률 할인 쿠폰을 생성할 때, ")
+    @Nested
+    class CreatePercentageCoupon {
+        @DisplayName("할인율이 null 이면, 생성에 실패한다.")
+        @Test
+        void failCreatePercentageCoupon_whenDiscountRateIsNull() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", null, 10000L, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("정률 할인 쿠폰은 할인율이 필수 입니다.");
+        }
+
+        @DisplayName("할인율이 0 이하 이면, 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, -1111L})
+        void failCreatePercentageCoupon_whenDiscountRateIsZeroOrLess(long discountRate) {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", discountRate, 10000L, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("할인율은 0 보다 커야 합니다.");
+        }
+
+        @DisplayName("최대 할인 가격이 null 이면, 생성에 실패한다.")
+        @Test
+        void failCreatePercentageCoupon_whenMaximumDiscountAmountIsNull() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", 10L, null, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("정률 할인 쿠폰은 최대 할인 가격이 필수입니다.");
+        }
+
+        @DisplayName("최대 할인 가격이 0 이하이면, 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, -1111L})
+        void failCreatePercentageCoupon_whenMaximumDiscountAmountIsZeroOrLess(long maximumDiscountAmount) {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class,
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", 10L, maximumDiscountAmount, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("최대 할인 가격은 0 보다 커야합니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.coupon;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,6 +40,31 @@ public class CouponTest {
             // assert
             assertThat(exception.getMessage()).isEqualTo("쿠폰 이름은 비어있을 수 없습니다.");
         }
+
+        @DisplayName("할인 최소 가격이 null 이면, 생성에 실패한다.")
+        @Test
+        void fail_whenMinimumOrderAmountIsNull() {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class, () ->
+                Coupon.fixedAmount("쿠폰", "쿠폰 설명", 5000L, null, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("할인 최소 가격은 필수입니다.");
+        }
+
+        @DisplayName("할인 최소 가격이 0 미만이면, 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, -1111L})
+        void fail_whenMinimumOrderAmountIsLessThanZero(long minimumOrderAmount) {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class, () ->
+                Coupon.fixedAmount("쿠폰", "쿠폰 설명", 5000L, minimumOrderAmount, null)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("할인 최소 가격은 0이상이어야 합니다.");
+        }
     }
 
     @DisplayName("정액 쿠폰을 생성할 때, ")
@@ -68,18 +96,6 @@ public class CouponTest {
             assertThat(exception.getMessage()).isEqualTo("정액 할인 가격은 0 보다 커야합니다.");
         }
 
-        @DisplayName("할인 최소 가격이 null 이면, 생성에 실패한다.")
-        @Test
-        void failCreateFixedCoupon_whenMinimumDiscountAmountIsNull() {
-            // act
-            var exception = assertThrows(IllegalArgumentException.class,
-                () -> Coupon.fixedAmount("쿠폰", "쿠폰쿠폰", 1000L, null, null)
-            );
-
-            // assert
-            assertThat(exception.getMessage()).isEqualTo("정액 할인 쿠폰은 할인 최소 가격이 필수입니다.");
-        }
-
         @DisplayName("할인 최소 가격이 0보다 작으면, 생성에 실패한다.")
         @ParameterizedTest
         @ValueSource(longs = {-1L, -1111L})
@@ -102,7 +118,7 @@ public class CouponTest {
         void failCreatePercentageCoupon_whenDiscountRateIsNull() {
             // act
             var exception = assertThrows(IllegalArgumentException.class,
-                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", null, 10000L, null)
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", null, 10000L, 10000L, null)
             );
 
             // assert
@@ -115,7 +131,7 @@ public class CouponTest {
         void failCreatePercentageCoupon_whenDiscountRateIsZeroOrLess(long discountRate) {
             // act
             var exception = assertThrows(IllegalArgumentException.class,
-                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", discountRate, 10000L, null)
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", discountRate, 10000L, 10000L, null)
             );
 
             // assert
@@ -127,7 +143,7 @@ public class CouponTest {
         void failCreatePercentageCoupon_whenMaximumDiscountAmountIsNull() {
             // act
             var exception = assertThrows(IllegalArgumentException.class,
-                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", 10L, null, null)
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", 10L, 10000L, null, null)
             );
 
             // assert
@@ -140,11 +156,90 @@ public class CouponTest {
         void failCreatePercentageCoupon_whenMaximumDiscountAmountIsZeroOrLess(long maximumDiscountAmount) {
             // act
             var exception = assertThrows(IllegalArgumentException.class,
-                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", 10L, maximumDiscountAmount, null)
+                () -> Coupon.percentage("쿠폰", "쿠폰쿠폰", 10L, 10000L, maximumDiscountAmount, null)
             );
 
             // assert
             assertThat(exception.getMessage()).isEqualTo("최대 할인 가격은 0 보다 커야합니다.");
+        }
+    }
+
+    @DisplayName("쿠폰을 사용할 때, ")
+    @Nested
+    class Use {
+        @DisplayName("정액 할인 쿠폰인 경우, 최소 주문 금액 보다 주문 가격이 크거나 같으면 허용한다.")
+        @Test
+        void useCoupon_whenFixedAmountCouponWithValidTotalPrice() {
+            // arrange
+            Coupon coupon = Coupon.fixedAmount("정액 할인 쿠폰", "쿠폰 설명", 5000L, 20000L, null);
+
+            // act
+            UserCoupon userCoupon = coupon.apply(1L, BigDecimal.valueOf(20000), new FixedAmountDiscountStrategy());
+
+            // assert
+            assertAll(
+                () -> assertThat(userCoupon.getUserId()).isEqualTo(1L),
+                () -> assertThat(userCoupon.getDiscountAmount()).isEqualByComparingTo(BigDecimal.valueOf(5000))
+            );
+        }
+
+        @DisplayName("정액 할인 쿠폰인 경우, 최소 주문 금액 보다 주문 가격이 작으면 예외를 발생한다.")
+        @Test
+        void useCoupon_whenFixedAmountCouponWithInValidTotalPrice() {
+            // arrange
+            Coupon coupon = Coupon.fixedAmount("정액 할인 쿠폰", "쿠폰 설명", 5000L, 20000L, null);
+
+            // act
+            var exception = assertThrows(IllegalStateException.class, () ->
+                coupon.apply(1L, BigDecimal.valueOf(19999), new FixedAmountDiscountStrategy())
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("적용할 수 없는 쿠폰입니다. 주문 최소 가격: 20000, 현재 가격: 19999");
+        }
+
+        @DisplayName("정률 할인 쿠폰인 경우, 최소 주문 금액 보다 주문 가격이 크거나 같으면 허용한다.")
+        @Test
+        void useCoupon_whenPercentageCouponWithValidTotalPrice() {
+            // arrange
+            Coupon coupon = Coupon.percentage("정액 할인 쿠폰", "쿠폰 설명", 10L, 20000L, 3000L, null);
+
+            // act
+            UserCoupon userCoupon = coupon.apply(1L, BigDecimal.valueOf(20000), new PercentageDiscountStrategy());
+
+            // assert
+            assertAll(
+                () -> assertThat(userCoupon.getUserId()).isEqualTo(1L),
+                () -> assertThat(userCoupon.getDiscountAmount()).isEqualByComparingTo(BigDecimal.valueOf(2000))
+            );
+        }
+
+        @DisplayName("정액 할인 쿠폰인 경우, 최소 주문 금액 보다 주문 가격이 작으면 예외를 발생한다.")
+        @Test
+        void useCoupon_whenPercentageCouponWithInValidTotalPrice() {
+            // arrange
+            Coupon coupon = Coupon.percentage("정액 할인 쿠폰", "쿠폰 설명", 10L, 20000L, 3000L, null);
+
+            // act
+            var exception = assertThrows(IllegalStateException.class, () ->
+                coupon.apply(1L, BigDecimal.valueOf(19999), new PercentageDiscountStrategy())
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("적용할 수 없는 쿠폰입니다. 주문 최소 가격: 20000, 현재 가격: 19999");
+        }
+
+        @DisplayName("정액 할인 쿠폰인 경우, 할인 가격은 소수점 첫째자리에서 올림한다.")
+        @Test
+        void useCoupon_whenPercentageCouponWithRoundingUp() {
+            // arrange
+            Coupon coupon = Coupon.percentage("정액 할인 쿠폰", "쿠폰 설명", 7L, 4000L, 500L, null);
+
+            // act
+            UserCoupon userCoupon = coupon.apply(1L, BigDecimal.valueOf(4320), new PercentageDiscountStrategy());
+
+            // assert
+            assertThat(userCoupon.getDiscountAmount()).isEqualByComparingTo(BigDecimal.valueOf(303)); // 4320 * 0.07 = 302.4
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- Coupon 도메인을 구현합니다. 
- 유저의 쿠폰 사용 기록을 저장하는 UserCoupon 도메인을 구현합니다.
- 쿠폰 사용기능을 구현합니다.

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->
## 쿠폰 사용기능 설계 
> 쿠폰 발급 기능 없이 쿠폰 사용기능을 구현합니다. 
- 하나의 쿠폰에 대해 미리 쿠폰을 발급하는 것은 유저가 많을 수록 서버에 부담이 있을 것이라고 판단. 
- 유저의 쿠폰 소유 여부는 user_coupon 테이블에 데이터가 존재하는지 여부로 판단.
- 선착순 쿠폰 같이 특정 사용자만 사용할 수 있는 쿠폰에 한해서만 추후 보유 쿠폰 기능을 추가할 예정.


## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
- [x] 동시성 테스트 코드 포함

