### PR TITLE
[FEAT] 쿠폰 선착순 발급 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 public interface CouponRepository {
     Coupon save(Coupon coupon);
 
-    Optional<Coupon> find(Long id);
+    Optional<Coupon> findForUpdate(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -3,6 +3,7 @@ package com.loopers.domain.coupon;
 import java.math.BigDecimal;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -16,8 +17,9 @@ public class CouponService {
     private final UserCouponRepository userCouponRepository;
     private final CouponDiscountStrategyFactory discountStrategyFactory;
 
+    @Transactional
     public UserCoupon apply(Long userId, Long couponId, BigDecimal totalPrice) {
-        Coupon coupon = couponRepository.find(couponId)
+        Coupon coupon = couponRepository.findForUpdate(couponId)
             .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[ID = " + couponId + "] 존재하지 않는 쿠폰입니다."));
         if (userCouponRepository.exists(userId, couponId)) {
             throw new CoreException(ErrorType.BAD_REQUEST, "이미 사용한 쿠폰입니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponCoreRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponCoreRepository.java
@@ -20,7 +20,7 @@ public class CouponCoreRepository implements CouponRepository {
     }
 
     @Override
-    public Optional<Coupon> find(Long id) {
-        return couponJpaRepository.findById(id);
+    public Optional<Coupon> findForUpdate(Long id) {
+        return couponJpaRepository.findByIdForUpdate(id);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,8 +1,17 @@
 package com.loopers.infrastructure.coupon;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import com.loopers.domain.coupon.Coupon;
 
+import jakarta.persistence.LockModeType;
+
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from Coupon c where c.id = :id")
+    Optional<Coupon> findByIdForUpdate(Long id);
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -65,6 +65,19 @@ public class CouponTest {
             // assert
             assertThat(exception.getMessage()).isEqualTo("할인 최소 가격은 0이상이어야 합니다.");
         }
+
+        @DisplayName("사용 한도가 0 이하이면, 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, 0L})
+        void fail_whenLimitCount(long limitCount) {
+            // act
+            var exception = assertThrows(IllegalArgumentException.class, () ->
+                Coupon.fixedAmount("쿠폰", "쿠폰 설명", 5000L, 10L, limitCount)
+            );
+
+            // assert
+            assertThat(exception.getMessage()).isEqualTo("사용 한도는 0보다 커야합니다.");
+        }
     }
 
     @DisplayName("정액 쿠폰을 생성할 때, ")


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- 쿠폰의 선착순 발급 기능을 구현합니다. 
- 비관적락을 적용하여 쿠폰 한도 만큼만 발급되도록 합니다. 

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

- issuedCount 없이 해결하려고 했으나 불가능했음.
  - 실제 데이터베이스에 발급된 개수를 쿼리로 가져오면 쿼리를 읽는 동안 락을 걸더라도 여러 스레드가 같은 숫자를 읽어올 가능성이 높기 때문에 해결 불가능 
  - 분산락을 적용하기엔 이름
  - issuedCount 를 두어 락을 위한 카운트로 남김.
  - 더 고찰 필요함.

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
- [x] 테스트 코드 포함

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->