### PR TITLE
[FEAT] 커머스 통계 정보를 관리하기 위한 모듈, product metrics 를 관리하는 기능 추가

### DIFF
--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
     implementation(project(":modules:kafka"))
+    implementation(project(":modules:commerce-analytics"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/application/analytics/ProductMetricsFacade.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/application/analytics/ProductMetricsFacade.kt
@@ -1,0 +1,35 @@
+package com.loopers.application.analytics
+
+import com.loopers.domain.analytics.ProductMetricsCommand
+import com.loopers.domain.analytics.ProductMetricsEvent
+import com.loopers.domain.analytics.ProductMetricsService
+import com.loopers.domain.common.EventDeduplicator
+import com.loopers.domain.common.InternalMessage
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class ProductMetricsFacade(
+    private val eventDeduplicator: EventDeduplicator,
+    private val productMetricsService: ProductMetricsService,
+) {
+    fun upsert(messages: List<InternalMessage<ProductMetricsEvent>>) {
+        messages
+            .filter { eventDeduplicator.checkAndMarkAsProcessed(it.metadata.eventId) }
+            .forEach { message ->
+                val evt = message.payload
+                val ts = runCatching { LocalDateTime.parse(evt.generatedAt) }.getOrNull()
+                val cmd = ProductMetricsCommand.Upsert(
+                    productId = evt.productId,
+                    periodType = evt.periodType,
+                    periodKey = evt.periodKey,
+                    version = evt.version,
+                    likes = evt.likes,
+                    views = evt.views,
+                    orderCount = evt.orderCount,
+                    generatedAt = ts,
+                )
+                productMetricsService.upsert(cmd)
+            }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/config/analytics/ProductMetricsPublishProperties.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/config/analytics/ProductMetricsPublishProperties.kt
@@ -1,0 +1,11 @@
+package com.loopers.config.analytics
+
+import com.loopers.domain.analytics.PeriodType
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "analytics.product-metrics")
+data class ProductMetricsPublishProperties(
+    val periodType: PeriodType = PeriodType.DAILY,
+    val zoneId: String = "Asia/Seoul",
+    val version: String,
+)

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsCommand.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsCommand.kt
@@ -1,0 +1,16 @@
+package com.loopers.domain.analytics
+
+import java.time.LocalDateTime
+
+class ProductMetricsCommand {
+    data class Upsert(
+        val productId: Long,
+        val periodType: PeriodType,
+        val periodKey: String,
+        val version: String,
+        val likes: Long? = null,
+        val views: Long? = null,
+        val orderCount: Long? = null,
+        val generatedAt: LocalDateTime? = null,
+    )
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsEvent.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsEvent.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.analytics
+
+import com.loopers.domain.analytics.PeriodType as PeriodTypeEnum
+
+data class ProductMetricsEvent(
+    val productId: Long,
+    val periodType: PeriodTypeEnum,
+    val periodKey: String,
+    val version: String,
+    val likes: Long? = null,
+    val views: Long? = null,
+    val orderCount: Long? = null,
+    val generatedAt: String? = null,
+)

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsPublishService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsPublishService.kt
@@ -1,0 +1,97 @@
+package com.loopers.domain.analytics
+
+import com.loopers.config.analytics.ProductMetricsPublishProperties
+import com.loopers.domain.common.InternalMessage
+import com.loopers.domain.order.OrderService
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.usersignal.TargetType
+import com.loopers.domain.usersignal.UserSignalEvent
+import com.loopers.domain.usersignal.UserSignalRepository
+import com.loopers.infrastructure.analytics.ProductMetricsEventPublisher
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZoneId
+import java.time.temporal.WeekFields
+
+@Component
+class ProductMetricsPublishService(
+    private val metricsProps: ProductMetricsPublishProperties,
+    private val publisher: ProductMetricsEventPublisher,
+    private val userSignalRepository: UserSignalRepository,
+    private val orderService: OrderService,
+) {
+    fun publishFromUserSignals(messages: List<InternalMessage<UserSignalEvent>>) {
+        if (messages.isEmpty()) return
+        val zone = ZoneId.of(metricsProps.zoneId)
+        val periodType = metricsProps.periodType
+        val periodKey = currentPeriodKey(periodType, zone)
+
+        val impactedProducts = messages
+            .map { it.payload }
+            .filter { it.targetType == TargetType.PRODUCT }
+            .map { it.targetId }
+            .toSet()
+
+        if (impactedProducts.isEmpty()) return
+
+        val events = impactedProducts.mapNotNull { productId ->
+            val us = userSignalRepository.findForUpdate(productId, TargetType.PRODUCT) ?: return@mapNotNull null
+            ProductMetricsEvent(
+                productId = productId,
+                periodType = periodType,
+                periodKey = periodKey,
+                version = metricsProps.version,
+                likes = us.likeCount,
+                views = us.views,
+                orderCount = null,
+                generatedAt = null,
+            )
+        }
+        publisher.publish(events)
+    }
+
+    fun publishFromOrders(messages: List<InternalMessage<PaymentEvent>>) {
+        if (messages.isEmpty()) return
+        val orderIds = messages.map { it.payload.orderId }
+        if (orderIds.isEmpty()) return
+
+        val orders = orderService.findAll(orderIds)
+        val productOrderCounts = orders
+            .flatMap { it.items }
+            .groupBy { it.productId }
+            .mapValues { (_, items) -> items.sumOf { it.quantity.toLong() } }
+        if (productOrderCounts.isEmpty()) return
+
+        val zone = ZoneId.of(metricsProps.zoneId)
+        val periodType = metricsProps.periodType
+        val periodKey = currentPeriodKey(periodType, zone)
+
+        val events = productOrderCounts.map { (productId, count) ->
+            ProductMetricsEvent(
+                productId = productId,
+                periodType = periodType,
+                periodKey = periodKey,
+                version = metricsProps.version,
+                likes = null,
+                views = null,
+                orderCount = count,
+                generatedAt = null,
+            )
+        }
+        publisher.publish(events)
+    }
+
+    private fun currentPeriodKey(type: PeriodType, zone: ZoneId): String = when (type) {
+        PeriodType.DAILY -> LocalDate.now(zone).toString()
+        PeriodType.WEEKLY -> {
+            val today = LocalDate.now(zone)
+            val week = today.get(WeekFields.ISO.weekOfWeekBasedYear())
+            val year = today.get(WeekFields.ISO.weekBasedYear())
+            "%04d-%02d".format(year, week)
+        }
+
+        PeriodType.MONTHLY -> YearMonth.now(zone).toString()
+    }
+}
+

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/analytics/ProductMetricsService.kt
@@ -1,0 +1,24 @@
+package com.loopers.domain.analytics
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProductMetricsService(
+    private val productMetricsRepository: ProductMetricsRepository,
+) {
+    @Transactional
+    fun upsert(command: ProductMetricsCommand.Upsert) {
+        productMetricsRepository.upsert(
+            command.productId,
+            command.periodType,
+            command.periodKey,
+            command.version,
+            command.likes,
+            command.views,
+            command.orderCount,
+            command.generatedAt,
+        )
+    }
+}
+

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/analytics/ProductMetricsEventPublisher.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/analytics/ProductMetricsEventPublisher.kt
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.analytics
+
+import com.loopers.domain.analytics.ProductMetricsEvent
+import com.loopers.domain.common.InternalMessage
+import com.loopers.domain.common.Metadata
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Component
+class ProductMetricsEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<Any, Any>,
+    @Value("\${kafka.topic.product-metrics.topic}") private val topic: String,
+    @Value("\${kafka.topic.product-metrics.version}") private val version: String,
+) {
+    fun publish(events: List<ProductMetricsEvent>) {
+        if (events.isEmpty()) return
+        val publishedAt = OffsetDateTime.now().toString()
+        events.forEach { evt ->
+            val message = InternalMessage(
+                metadata = Metadata(eventId = UUID.randomUUID().toString(), version = version, publishedAt = publishedAt),
+                payload = evt
+            )
+            kafkaTemplate.send(topic, message)
+        }
+    }
+}
+

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/analytics/ProductMetricsKafkaConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/analytics/ProductMetricsKafkaConsumer.kt
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.consumer.analytics
+
+import com.loopers.application.analytics.ProductMetricsFacade
+import com.loopers.config.kafka.KafkaConfig
+import com.loopers.domain.analytics.ProductMetricsEvent
+import com.loopers.domain.common.InternalMessage
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class ProductMetricsKafkaConsumer(
+    private val productMetricsFacade: ProductMetricsFacade
+) {
+    @KafkaListener(
+        topics = ["\${kafka.topic.product-metrics.topic}"],
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+        groupId = "\${kafka.topic.product-metrics.group-id}"
+    )
+    fun consume(records: List<InternalMessage<ProductMetricsEvent>>, acknowledgment: Acknowledgment) {
+        productMetricsFacade.upsert(records)
+        acknowledgment.acknowledge()
+    }
+}
+

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -25,6 +25,14 @@ spring:
       - logging.yml
       - monitoring.yml
 
+analytics:
+  product-metrics:
+    # default period type and zone to derive periodKey
+    period-type: DAILY
+    zone-id: Asia/Seoul
+    # reuse kafka topic version for payload version
+    version: ${kafka.topic.product-metrics.version}
+
 demo-kafka:
   test:
     topic-name: demo.internal.topic-v1
@@ -45,6 +53,10 @@ kafka:
     rank-order:
       version: 1.0.0
       group-id: rank-order-consumer
+    product-metrics:
+      version: 1.0.0
+      topic: product-metrics
+      group-id: product-metrics-consumer
 ---
 spring:
   config:

--- a/apps/commerce-streamer/src/test/kotlin/com/loopers/application/analytics/ProductMetricsIntegrationTest.kt
+++ b/apps/commerce-streamer/src/test/kotlin/com/loopers/application/analytics/ProductMetricsIntegrationTest.kt
@@ -1,0 +1,67 @@
+package com.loopers.application.analytics
+
+import com.loopers.domain.analytics.PeriodType
+import com.loopers.domain.analytics.ProductMetricsEvent
+import com.loopers.domain.analytics.ProductMetricsRepository
+import com.loopers.domain.common.InternalMessage
+import com.loopers.domain.common.Metadata
+import com.loopers.support.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+class ProductMetricsIntegrationTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var facade: ProductMetricsFacade
+
+    @Autowired
+    private lateinit var repository: ProductMetricsRepository
+
+    @Test
+    fun `상품 메트릭 이벤트를 전달받아 실제 DB에 업서트로 저장한다`() {
+        // arrange
+        val msg1 = InternalMessage(
+            metadata = Metadata(eventId = "e1", version = "1.0.0", publishedAt = LocalDateTime.now().toString()),
+            payload = ProductMetricsEvent(
+                productId = 10L,
+                periodType = PeriodType.DAILY,
+                periodKey = "2025-09-16",
+                version = "v1",
+                likes = 3,
+                views = 20,
+                orderCount = null,
+                generatedAt = "2025-09-16T10:00:00"
+            ),
+        )
+        val msg2 = InternalMessage(
+            metadata = Metadata(eventId = "e2", version = "1.0.0", publishedAt = LocalDateTime.now().toString()),
+            payload = ProductMetricsEvent(
+                productId = 20L,
+                periodType = PeriodType.DAILY,
+                periodKey = "2025-09-16",
+                version = "v1",
+                likes = null,
+                views = null,
+                orderCount = 5,
+                generatedAt = null,
+            ),
+        )
+
+        // act
+        facade.upsert(listOf(msg1, msg2))
+
+        // assert
+        val saved1 = repository.find(10L, PeriodType.DAILY, "2025-09-16", "v1").orElseThrow()
+        assertThat(saved1.likes).isEqualTo(3)
+        assertThat(saved1.views).isEqualTo(20)
+        assertThat(saved1.orderCount).isEqualTo(0)
+
+        val saved2 = repository.find(20L, PeriodType.DAILY, "2025-09-16", "v1").orElseThrow()
+        assertThat(saved2.likes).isEqualTo(0)
+        assertThat(saved2.views).isEqualTo(0)
+        assertThat(saved2.orderCount).isEqualTo(5)
+    }
+}
+

--- a/apps/commerce-streamer/src/test/kotlin/com/loopers/infrastructure/analytics/ProductMetricsEventPublisherTest.kt
+++ b/apps/commerce-streamer/src/test/kotlin/com/loopers/infrastructure/analytics/ProductMetricsEventPublisherTest.kt
@@ -1,0 +1,54 @@
+package com.loopers.infrastructure.analytics
+
+import com.loopers.domain.analytics.PeriodType
+import com.loopers.domain.analytics.ProductMetricsEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.*
+import org.springframework.kafka.core.KafkaTemplate
+
+class ProductMetricsEventPublisherTest {
+
+    @Test
+    fun `상품 메트릭 이벤틀르 발송한다`() {
+        // arrange
+        val kafkaTemplate = mock(KafkaTemplate::class.java) as KafkaTemplate<Any, Any>
+        val publisher = ProductMetricsEventPublisher(kafkaTemplate, "product-metrics", "1.0.0")
+
+        val events = listOf(
+            ProductMetricsEvent(
+                1L,
+                PeriodType.DAILY,
+                "2025-09-16",
+                "v1",
+                likes = 10,
+                views = 100,
+                orderCount = null,
+                generatedAt = null
+            ),
+            ProductMetricsEvent(
+                2L,
+                PeriodType.DAILY,
+                "2025-09-16",
+                "v1",
+                likes = 5,
+                views = 40,
+                orderCount = 3,
+                generatedAt = null
+            )
+        )
+
+        // act
+        publisher.publish(events)
+
+        // assert
+        val captor = ArgumentCaptor.forClass(Any::class.java)
+        verify(kafkaTemplate, times(2)).send(eq("product-metrics"), captor.capture())
+        val messages = captor.allValues
+        assertEquals(2, messages.size)
+        val first = messages[0]
+        assertNotNull(first)
+    }
+}

--- a/apps/commerce-streamer/src/test/kotlin/com/loopers/support/IntegrationTest.kt
+++ b/apps/commerce-streamer/src/test/kotlin/com/loopers/support/IntegrationTest.kt
@@ -1,0 +1,28 @@
+package com.loopers.support
+
+import com.loopers.testcontainers.MySqlTestContainersConfig
+import com.loopers.testcontainers.RedisTestContainersConfig
+import com.loopers.utils.DatabaseCleanUp
+import com.loopers.utils.RedisCleanUp
+import org.junit.jupiter.api.AfterEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+
+@SpringBootTest
+@Import(MySqlTestContainersConfig::class, RedisTestContainersConfig::class)
+abstract class IntegrationTest {
+
+    @Autowired
+    private lateinit var databaseCleanUp: DatabaseCleanUp
+
+    @Autowired
+    private lateinit var redisCleanUp: RedisCleanUp
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+        redisCleanUp.truncateAll()
+    }
+}
+

--- a/modules/commerce-analytics/build.gradle.kts
+++ b/modules/commerce-analytics/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":modules:jpa"))
+}

--- a/modules/commerce-analytics/src/main/java/com/loopers/domain/analytics/PeriodType.java
+++ b/modules/commerce-analytics/src/main/java/com/loopers/domain/analytics/PeriodType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.analytics;
+
+public enum PeriodType {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/modules/commerce-analytics/src/main/java/com/loopers/domain/analytics/ProductMetrics.java
+++ b/modules/commerce-analytics/src/main/java/com/loopers/domain/analytics/ProductMetrics.java
@@ -1,0 +1,122 @@
+package com.loopers.domain.analytics;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "product_metrics",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "period_type", "period_key", "version"})
+)
+public class ProductMetrics {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period_type", nullable = false, length = 16)
+    private PeriodType periodType;
+
+    @Column(name = "period_key", nullable = false, length = 32)
+    private String periodKey;
+
+    @Column(name = "version", nullable = false, length = 32)
+    private String version;
+
+    @Column(name = "likes", nullable = false)
+    private Long likes;
+
+    @Column(name = "views", nullable = false)
+    private Long views;
+
+    @Column(name = "order_count", nullable = false)
+    private Long orderCount;
+
+    
+
+    @Column(name = "generated_at", nullable = false)
+    private LocalDateTime generatedAt;
+
+    protected ProductMetrics() {
+    }
+
+    public ProductMetrics(
+        Long productId,
+        PeriodType periodType,
+        String periodKey,
+        String version,
+        Long likes,
+        Long views,
+        Long orderCount,
+        LocalDateTime generatedAt
+    ) {
+        this.productId = productId;
+        this.periodType = periodType;
+        this.periodKey = periodKey;
+        this.version = version;
+        this.likes = likes != null ? likes : 0L;
+        this.views = views != null ? views : 0L;
+        this.orderCount = orderCount != null ? orderCount : 0L;
+        this.generatedAt = generatedAt != null ? generatedAt : LocalDateTime.now();
+    }
+
+    public void updateValues(Long likes, Long views, Long orderCount, LocalDateTime generatedAt) {
+        if (likes != null)
+            this.likes = likes;
+        if (views != null)
+            this.views = views;
+        if (orderCount != null)
+            this.orderCount = orderCount;
+        if (generatedAt != null)
+            this.generatedAt = generatedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public PeriodType getPeriodType() {
+        return periodType;
+    }
+
+    public String getPeriodKey() {
+        return periodKey;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Long getLikes() {
+        return likes;
+    }
+
+    public Long getViews() {
+        return views;
+    }
+
+    public Long getOrderCount() {
+        return orderCount;
+    }
+
+    public LocalDateTime getGeneratedAt() {
+        return generatedAt;
+    }
+}

--- a/modules/commerce-analytics/src/main/java/com/loopers/domain/analytics/ProductMetricsRepository.java
+++ b/modules/commerce-analytics/src/main/java/com/loopers/domain/analytics/ProductMetricsRepository.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.analytics;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface ProductMetricsRepository {
+
+    Optional<ProductMetrics> find(Long productId, PeriodType periodType, String periodKey, String version);
+
+    ProductMetrics save(ProductMetrics metrics);
+
+    ProductMetrics upsert(
+        Long productId,
+        PeriodType periodType,
+        String periodKey,
+        String version,
+        Long likes,
+        Long views,
+        Long orderCount,
+        LocalDateTime generatedAt
+    );
+}

--- a/modules/commerce-analytics/src/main/java/com/loopers/infrastructure/analytics/ProductMetricsCoreRepository.java
+++ b/modules/commerce-analytics/src/main/java/com/loopers/infrastructure/analytics/ProductMetricsCoreRepository.java
@@ -1,0 +1,60 @@
+package com.loopers.infrastructure.analytics;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.loopers.domain.analytics.PeriodType;
+import com.loopers.domain.analytics.ProductMetrics;
+import com.loopers.domain.analytics.ProductMetricsRepository;
+
+@Component
+@Transactional
+public class ProductMetricsCoreRepository implements ProductMetricsRepository {
+
+    private final ProductMetricsJpaRepository jpaRepository;
+
+    public ProductMetricsCoreRepository(ProductMetricsJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<ProductMetrics> find(Long productId, PeriodType periodType, String periodKey, String version) {
+        return jpaRepository.findByProductIdAndPeriodTypeAndPeriodKeyAndVersion(productId, periodType, periodKey, version);
+    }
+
+    @Override
+    public ProductMetrics save(ProductMetrics metrics) {
+        return jpaRepository.save(metrics);
+    }
+
+    @Override
+    public ProductMetrics upsert(Long productId,
+        PeriodType periodType,
+        String periodKey,
+        String version,
+        Long likes,
+        Long views,
+        Long orderCount,
+        LocalDateTime generatedAt) {
+        try {
+            var existing = find(productId, periodType, periodKey, version);
+            if (existing.isPresent()) {
+                var entity = existing.get();
+                entity.updateValues(likes, views, orderCount, generatedAt);
+                return save(entity);
+            }
+            var created = new ProductMetrics(productId, periodType, periodKey, version, likes, views, orderCount, generatedAt);
+            return save(created);
+        } catch (DataIntegrityViolationException e) {
+            // handle rare race: another thread inserted same natural key
+            var retry = find(productId, periodType, periodKey, version)
+                .orElseThrow(() -> e);
+            retry.updateValues(likes, views, orderCount, generatedAt);
+            return save(retry);
+        }
+    }
+}

--- a/modules/commerce-analytics/src/main/java/com/loopers/infrastructure/analytics/ProductMetricsJpaRepository.java
+++ b/modules/commerce-analytics/src/main/java/com/loopers/infrastructure/analytics/ProductMetricsJpaRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.analytics;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.loopers.domain.analytics.PeriodType;
+import com.loopers.domain.analytics.ProductMetrics;
+
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
+    Optional<ProductMetrics> findByProductIdAndPeriodTypeAndPeriodKeyAndVersion(
+        Long productId,
+        PeriodType periodType,
+        String periodKey,
+        String version
+    );
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(
     ":modules:jpa",
     ":modules:redis",
     ":modules:kafka",
+    ":modules:commerce-analytics",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
  - 목적: Redis 일간 지표를 기반으로 주/월 랭킹을 구축하기 위한 기초 작업
  - 범위:
      - 배치 앱 모듈 추가(Kotlin, Spring Batch)
      - 공용 도메인 분리(modules:commerce-analytics, Java)
      - 스트리머에서 product-metrics 이벤트 발행→셀프컨슘→DB 업서트 저장 파이프라인
      - 설정 외부화(기간 타입/존/버전), 테스트(통합/단위)
## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

  - 신규 모듈
      - apps:commerce-batch
          - Kotlin + Spring Batch 기본 골격
          - 샘플 잡/스텝(Tasklet) 구성
          - 의존성: spring-boot-starter-batch, modules:jpa, modules:redis, supports(logging/monitoring/jackson)
          - 설정: application.yml에 jpa.yml, redis.yml, logging.yml, monitoring.yml import
          - 프로필: 로컬/테스트 spring.batch.jdbc.initialize-schema=always, 운영계 never
      - modules:commerce-analytics (Java)
          - PeriodType: DAILY|WEEKLY|MONTHLY
          - ProductMetrics 엔티티
              - 테이블: product_metrics
              - 자연키 유니크: (product_id, period_type, period_key, version)
              - 컬럼: productId, periodType, periodKey, version, likes, views, orderCount, generatedAt
              - likes/views/orderCount 모두 not null, 기본값 0으로 저장
          - 저장소
              - ProductMetricsRepository(포트), ProductMetricsJpaRepository(Spring Data)
              - ProductMetricsCoreRepository(업서트 구현: 조회→갱신/생성, 유니크 충돌 시 재조회 업데이트)
  - 스트리머 파이프라인(카프카 소비→재발행→셀프컨슘→DB 업서트)
      - 의존성: apps:commerce-streamer에 modules:commerce-analytics 추가
      - 이벤트 모델
          - ProductMetricsEvent(payload): productId, periodType, periodKey, version, likes?, views?, orderCount?, generatedAt?
          - InternalMessage 메타데이터(eventId, version, publishedAt) 재사용
      - 발행자
          - ProductMetricsEventPublisher: kafka.topic.product-metrics.topic으로 InternalMessage 발행
      - 발행 서비스(분리)
          - ProductMetricsPublishService
              - 유저 시그널 경로: 영향 상품 집합 → UserSignal 조회 → (likes, views) 채워 이벤트 발행
              - 주문 경로: 주문 상세로 상품별 수량 합산 → (orderCount) 채워 이벤트 발행
              - 설정(analytics.product-metrics)로 periodType/zoneId/version 바탕의 periodKey 계산
      - 소비자
          - ProductMetricsKafkaConsumer: 배치 리스너 + 수동 ACK, dedup 후 Facade 위임
      - 저장 Facade/Service/Repository
          - ProductMetricsFacade: 이벤트→Command로 변환, dedup 처리
          - ProductMetricsService: Command를 Repository.upsert에 위임
          - ProductMetricsCommand.Upsert: 파라미터 일괄 전달용
      - Rank 경로 리팩터링
          - RankFacade: 점수 계산/적용만 수행
          - RankKafkaConsumer: dedup 후 RankFacade 호출, 이어서 ProductMetricsPublishService 호출
  - 설정
      - settings.gradle.kts: :apps:commerce-batch, :modules:commerce-analytics 포함
      - apps/commerce-streamer/src/main/resources/application.yml
          - kafka.topic.product-metrics.{topic,version,group-id} 추가
          - analytics.product-metrics.{period-type,zone-id,version} 추가
  - 테스트
      - 통합 테스트(SpringBootTest + Testcontainers)
          - 공통 베이스: apps/commerce-streamer/src/test/kotlin/com/loopers/support/IntegrationTest.kt
              - MySqlTestContainersConfig, RedisTestContainersConfig 임포트
              - DatabaseCleanUp, RedisCleanUp로 테스트 간 데이터 격리
          - ProductMetricsIntegrationTest
              - Facade.upsert 호출 → 실제 DB product_metrics에 저장 검증(기본값 0 포함)
      - 단위 테스트
          - ProductMetricsEventPublisherTest: KafkaTemplate.send 호출 검증

  설계 포인트

  - 자연키 유니크: (product, period_type, period_key, version)
      - 멱등/재실행/정정 안전성 확보, 실험/버전 공존 용이
      - 조회/인덱스 최적화: period_type + period_key 축으로 범위 조회
  - 기간 타입 필요성
      - 동일 period_key의 의미 충돌 방지(월/주), 계산 규칙/보관 정책 분리, 포맷 검증 용이
  - 이벤트 파이프라인
      - 기존 유저시그널/주문 이벤트 소비 → 점수 적용(랭킹)
      - 영향 상품에 대한 product-metrics 이벤트 재발행(셀프컨슘) → DB 스냅샷 저장
      - 실시간 서빙은 Redis, 스냅샷은 DB로 백업/정정/백필 대응

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->